### PR TITLE
Fix xml tmp file removal, fix for including too many xml files

### DIFF
--- a/convert.sh
+++ b/convert.sh
@@ -14,9 +14,9 @@ do
 	python "${PDF2TXT}" -o "${XML_FILE}.xml" "${PDF}" 
 done
 
-XML_FILES=($(find -H . -type f -regextype posix-extended -regex '\./.+\.xml' -print))
+XML_FILES=($(find -H . -maxdepth 1 -type f -regextype posix-extended -regex '\./.+\.xml' -print))
 
 echo "${XML_FILES[@]}"
 python convert.py "${OUTPUT_FILE}" "${XML_FILES[@]}"
 
-rm -rf .xml
+rm -rf *.xml


### PR DESCRIPTION
If you have a venv set up, the

    XML_FILES=(./venv/lib/python3.9/site-packages/setuptools/command/launcher manifest.xml)

line pulls in manifest.xml and another file inside the virtualenv dir.