### PR TITLE
feat: add savings support, robust Visa parser, and CSV write retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,219 @@
 *.pdf
 *.csv
 
-venv
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+# Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+# uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+# poetry.lock
+# poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+# pdm.lock
+# pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+# pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# Redis
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#   and can be added to the global gitignore or merged into this file.  For a more nuclear
+#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
+# .idea/
+
+# Abstra
+#   Abstra is an AI-powered process automation framework.
+#   Ignore directories containing user credentials, local state, and settings.
+#   Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RBC Statement To CSV
 
-This program reads transaction data out of RBC statements and writes them to CSVs.
+This tool converts Royal Bank of Canada (RBC) statements - Credit Card (Visa), Chequing, and Savings - into CSV files.
 
 Supported statements (CSV created only if at least one matching statement is processed):
 - Credit Card (Visa) → `credit_transactions.csv` with the following columns:
@@ -24,12 +24,10 @@ Supported statements (CSV created only if at least one matching statement is pro
 
 - Savings (identical layout to Chequing) → `savings_transactions.csv` with the same columns as chequing.
 
-## Requirements
-- Python 3.8+
-- [PdfMiner](https://github.com/pdfminer/pdfminer.six)
-- [python-dateutil](https://dateutil.readthedocs.io/en/stable/)
-
 ## Installation
+
+### Prerequisites
+- Python 3.8 or higher
 
 ### macOS
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,43 @@ Supported statements (CSV created only if at least one matching statement is pro
 - [PdfMiner](https://github.com/pdfminer/pdfminer.six)
 - [python-dateutil](https://dateutil.readthedocs.io/en/stable/)
 
-## Use
+## Installation
+
+### macOS
+
+1. Create a virtual environment:
+```bash
+python3 -m venv .venv
+```
+
+2. Activate the virtual environment:
+```bash
+source .venv/bin/activate
+```
+
+3. Install required packages:
+```bash
+pip install -r requirements.txt
+```
+
+### Windows
+
+1. Create a new Python virtual environment using PowerShell:
+```powershell
+python -m venv .venv
+```
+
+2. Activate the virtual environment:
+```powershell
+.venv\Scripts\activate
+```
+
+3. Install required packages:
+```powershell
+pip install -r requirements.txt
+```
+
+## Usage
 Drop all PDF statements into the project directory. The program will auto-discover PDFs in the current folder (or you can pass specific files on the command line), read all transactions, sort them, and write only the CSV file(s) that correspond to the statement types actually processed. Savings statements (e.g., `Savings Statement-4484 2025-01-15.pdf`) are processed the same as chequing but written to `savings_transactions.csv`.
 
 Notes:
@@ -37,10 +73,26 @@ Notes:
 - CSV files are only created when at least one matching statement is successfully processed (no empty header-only files).
 - If a CSV file is open in another program (e.g., Excel), the script will prompt you to close the file and press Enter, then retry writing.
 
+### macOS
+
+Run the script from a terminal:
+```bash
+python3 convert.py
+```
+
 ### Windows
-Ensure `.py` files are associated with Python.
 
-Run (double-click) `convert.py`.
+To run the script, you can either:
 
-### Linux/macOS
-Run `./convert.py` in a terminal.
+Double-click `convert.py`.
+
+> [!IMPORTANT]
+> Ensure `.py` files are associated with Python.
+
+or
+
+Run from PowerShell:
+
+```powershell
+python convert.py
+```

--- a/README.md
+++ b/README.md
@@ -1,21 +1,41 @@
 # RBC Statement To CSV
 
-This program will read transaction data out of RBC credit card statements and put them in a .csv file with the following columns:
+This program reads transaction data out of RBC statements and writes them to CSVs.
 
-- Transaction Date
-- Posting Date
-- Description
-- Amount
-- Amount In Foreign Currency
-- Foreign Currency
-- Exchange Rate
+Supported statements (CSV created only if at least one matching statement is processed):
+- Credit Card (Visa) → `credit_transactions.csv` with the following columns:
+
+  - Transaction Date
+  - Posting Date
+  - Description
+  - Credit
+  - Debit
+  - Amount Foreign Currency
+  - Foreign Currency
+  - Exchange Rate
+  - Raw
+
+- Chequing (identical layout to Savings) → `chequing_transactions.csv` with the following columns:
+  - Date
+  - Description
+  - Withdrawls
+  - Deposits
+  - Balance
+
+- Savings (identical layout to Chequing) → `savings_transactions.csv` with the same columns as chequing.
 
 ## Requirements
 - Python 3.8+
 - [PdfMiner](https://github.com/pdfminer/pdfminer.six)
+- [python-dateutil](https://dateutil.readthedocs.io/en/stable/)
 
 ## Use
-Drop all PDF statements into the project directory. The program will read all transactions, sort them, and consolidate them into a single .csv file.
+Drop all PDF statements into the project directory. The program will auto-discover PDFs in the current folder (or you can pass specific files on the command line), read all transactions, sort them, and write only the CSV file(s) that correspond to the statement types actually processed. Savings statements (e.g., `Savings Statement-4484 2025-01-15.pdf`) are processed the same as chequing but written to `savings_transactions.csv`.
+
+Notes:
+- Visa parsing supports both older and newer RBC layouts. FX details (Exchange rate and Foreign Currency) are extracted when present.
+- CSV files are only created when at least one matching statement is successfully processed (no empty header-only files).
+- If a CSV file is open in another program (e.g., Excel), the script will prompt you to close the file and press Enter, then retry writing.
 
 ### Windows
 Ensure `.py` files are associated with Python.

--- a/convert.py
+++ b/convert.py
@@ -1,200 +1,510 @@
-#! /usr/bin/env python3
-
-import argparse
+#!/usr/bin/env python3
 from datetime import datetime
-from glob import glob
-import io
-import pdfminer.high_level
+from dateutil.parser import parse
 import sys
 import xml.etree.ElementTree as ET
 import re
 import csv
+import os
+import glob
+from typing import List
 
-default_output_file = 'transactions.csv'
-re_exchange_rate = re.compile(r'Exchange rate-([0-9]+\.[0-9]+)', re.MULTILINE)
-re_foreign_currency = re.compile(r'Foreign Currency-([A-Z]+) ([0-9]+\.[0-9]+)', re.MULTILINE)
+# Lazy import of pdfminer when needed (keeps startup fast and avoids hard crash if not installed yet)
+def _pdf_to_xml_root(pdf_path: str):
+    from io import StringIO
+    try:
+        # Prefer high_level API with XML output
+        from pdfminer.high_level import extract_text_to_fp
+        from pdfminer.layout import LAParams
+    except Exception as e:
+        raise RuntimeError(
+            "pdfminer.six is required to parse PDFs. Install dependencies first (see requirements.txt)."
+        ) from e
+
+    output = StringIO()
+    with open(pdf_path, 'rb') as f:
+        extract_text_to_fp(f, output, laparams=LAParams(), output_type='xml', codec=None)
+    xml_text = output.getvalue()
+    try:
+        return ET.fromstring(xml_text)
+    except ET.ParseError as e:
+        # Surface a more actionable error with filename context
+        raise RuntimeError(f"Failed to parse XML converted from PDF: {pdf_path}. Error: {e}") from e
 
 
-def read_pdf_as_xml(input_file):
-    with open(input_file, "rb") as inf, io.BytesIO() as outf:
-        pdfminer.high_level.extract_text_to_fp(inf, outf, "xml")
-        return ET.fromstring(outf.getvalue())
+def _get_xml_root(input_path: str):
+    ext = os.path.splitext(input_path)[1].lower()
+    if ext == '.xml':
+        return ET.parse(input_path).getroot()
+    if ext == '.pdf':
+        return _pdf_to_xml_root(input_path)
+    raise ValueError(f"Unsupported input type for '{input_path}'. Expected .pdf or .xml")
 
 
-def read_txns_from_pdf(input_file):
-    root = read_pdf_as_xml(input_file)
-    rows = []
-    txns = []
-
-    print(f'Processing {input_file}...')
-
-    # Go through each page
-    for page in root:
-        # Txn rows are in the second figure
-        figure = page[1]
-        row = ''
-        last_x2 = None
-        # A row is a list of <text> tags, each containing a character
-        for tag in figure:
-            if tag.tag == 'text':
-                # Filter on text size to remove some of the noise
-                size = float(tag.attrib['size'])
-                x_pos = float(tag.attrib["bbox"].split(",")[0])
-                x2_pos = float(tag.attrib["bbox"].split(",")[2])
-
-                if last_x2 is not None:
-                    if x2_pos < last_x2:
-                        row += "\n"
-
-                    if len(row) > 10 and (x_pos - last_x2) > 0.7:
-                        row += " "
-                last_x2 = x2_pos
-                if size >= 5 and size <= 9:
-                    row += tag.text
-            elif tag.tag != 'text' and row != '':
-                # Row is over, start a new one
-                rows.append(row)
-                row = ''
-                last_x2 = None
-
-    # Get date range of the statement
-    date_range_regex = re.compile(r'^.*STATEMENT FROM ([A-Z]{3}) \d{2},? ?(\d{4})? TO ([A-Z]{3}) \d{2}, (\d{4})', re.MULTILINE)
-    date_range = {}
-
-    for row in rows:
-        if match := date_range_regex.search(row):
-            # Year for start month may not be specified if it's the same
-            # as the end month
-            date_range[match.group(1)] = match.group(2) or match.group(4)
-            date_range[match.group(3)] = match.group(4)
-            break
-
-    # Filter down to rows that are for transactions
-    MONTHS = {
-        'JAN',
-        'FEB',
-        'MAR',
-        'APR',
-        'MAY',
-        'JUN',
-        'JUL',
-        'AUG',
-        'SEP',
-        'OCT',
-        'NOV',
-        'DEC'
-    }
-    txn_rows = []
-
-    for row in rows:
-        # Match txn rows based on month of txn date and posting date
-        if len(row) >= 10:
-            month_1 = row[:3]
-            month_2 = row[5:8]
-
-            if month_1 in MONTHS and month_2 in MONTHS:
-                txn_rows.append(row)
-
-    # Parse and format the transaction data
-    for row in txn_rows:
-        date_1_month = row[:3]
-        date_1_day = row[3:5]
-        date_2_month = row[5:8]
-        date_2_day = row[8:10]
-
-        transaction_date = None
+def _write_csv_with_retry(output_file: str, write_callback):
+    """
+    Open a CSV file for writing and execute write_callback(writer).
+    If the file is locked (e.g., open in Excel), prompt the user to close it and press Enter to retry.
+    """
+    while True:
         try:
-            transaction_date = datetime.strptime(f'{date_1_month}-{date_1_day}-{date_range[date_1_month]}', '%b-%d-%Y')
-        except KeyError:
-            # there is a strange case where the first date was before the days specified in date_range
-            # so just use the first year
-            first_year = min([int(year) for year in date_range.values()])
-            transaction_date = datetime.strptime(f'{date_1_month}-{date_1_day}-{first_year}', '%b-%d-%Y')
-        posting_date = datetime.strptime(f'{date_2_month}-{date_2_day}-{date_range[date_2_month]}', '%b-%d-%Y')
+            with open(output_file, 'w', newline='') as csvfile:
+                writer = csv.writer(csvfile)
+                write_callback(writer)
+            break
+        except PermissionError:
+            print(f"Cannot write to '{output_file}' because it's open in another program.")
+            try:
+                input("Please close the file, then press Enter to retry...")
+            except KeyboardInterrupt:
+                print("Write cancelled by user.")
+                raise
 
-        description, amount = row[10:].split('$')
+output_file_credit = 'credit_transactions.csv'
+output_file_chequing = 'chequing_transactions.csv'
+output_file_savings = 'savings_transactions.csv'
+input_files = sys.argv[1:]
 
-        if description.endswith('-'):
-            description = description[:-1]
-            amount = '-' + amount
+font_header = "MetaBookLF-Roman"
+font_txn = "MetaBoldLF-Roman"
 
-        # split desc after negative check, otherwise `-` gets left behind
-        description = description.split("\n")[0]
-        raw = row.strip()
+class Block:
+    def __init__(self, page, x, x2, y, text):
+        self.page = page
+        self.x = x
+        self.x2 = x2
+        self.text = text
+        self.y = y
+    
+    def __repr__(self):
+        return f"<Block page={self.page} x={self.x} x2={self.x2} y={self.y} text={self.text} />"
 
-        amount = amount.replace(',', '').replace("\n", "")
-        match_exchange_rate = re_exchange_rate.search(raw)
-        match_foreign_currency = re_foreign_currency.search(raw)
-        txns.append({
-            'transaction_date': transaction_date,
-            'posting_date': posting_date,
-            'description': description,
-            'amount': amount,
-            'raw': raw,
-            'exchange_rate': match_exchange_rate.group(1) if match_exchange_rate else None,
-            'foreign_currency': match_foreign_currency.group(1) if match_foreign_currency else None,
-            'amount_foreign': match_foreign_currency.group(2) if match_foreign_currency else None,
-        })
+def process_credit_statements(input_files: List[str], output_file: str):
+    txns = []
+    re_exchange_rate = re.compile(r'Exchange rate-([0-9]+\.[0-9]+)', re.MULTILINE)
+    re_foreign_currency = re.compile(r'Foreign Currency-([A-Z]+) ([0-9]+\.[0-9]+)', re.MULTILINE)
 
-    return txns
+    for input_file in input_files:
+        root = _get_xml_root(input_file)
+        rows = []
 
+        print(f'Processing {input_file}...')
 
-def write_txns_to_csv(txns, output_file):
-    with open(output_file, 'w', newline='') as csvfile:
-        csv_writer = csv.writer(csvfile)
-        csv_writer.writerow([
-            'Transaction Date',
-            'Posting Date',
-            'Description',
-            'Amount',
-            'Amount Foreign Currency',
-            'Foreign Currency',
-            'Exchange Rate',
-            'Raw',
+        # Build line-oriented rows robustly by grouping text fragments by Y position
+        # Do not assume a fixed child index (page[1]) as pdfminer XML can vary.
+        pages = [el for el in list(root) if getattr(el, 'tag', None) == 'page']
+        if not pages:
+            # Fallback: find any nested page elements
+            pages = list(root.findall('.//page'))
+
+        for page in pages:
+            # Collect candidate text segments with coordinates
+            segments = []
+            for tag in page.iter('text'):
+                try:
+                    size = float(tag.attrib.get('size', '0'))
+                    if not (5 <= size <= 12):
+                        continue
+                    bbox = tag.attrib.get('bbox', '0,0,0,0').split(',')
+                    x_pos = float(bbox[0])
+                    y_pos = float(bbox[1])
+                    x2_pos = float(bbox[2])
+                    txt = tag.text or ''
+                    if not txt:
+                        continue
+                except Exception:
+                    continue
+                segments.append((y_pos, x_pos, x2_pos, txt))
+
+            if not segments:
+                continue
+
+            # Sort by Y descending (top to bottom), then X ascending (left to right)
+            segments.sort(key=lambda s: (-s[0], s[1]))
+
+            # Group into lines by Y with a small tolerance
+            y_tol = 0.9
+            line_items = []  # list of list of segments for each line
+            current_y = None
+            current_line = []
+            for y_pos, x_pos, x2_pos, txt in segments:
+                if current_y is None or abs(y_pos - current_y) > y_tol:
+                    if current_line:
+                        line_items.append(current_line)
+                    current_line = []
+                    current_y = y_pos
+                current_line.append((x_pos, x2_pos, txt))
+            if current_line:
+                line_items.append(current_line)
+
+            # For each grouped line, stitch text by X order, adding spaces on noticeable gaps
+            for items in line_items:
+                items.sort(key=lambda s: s[0])
+                line_text = ''
+                prev_x2 = None
+                for x_pos, x2_pos, txt in items:
+                    if prev_x2 is not None and (x_pos - prev_x2) > 0.7 and len(line_text) > 10:
+                        line_text += ' '
+                    line_text += txt
+                    prev_x2 = x2_pos
+                if line_text:
+                    rows.append(line_text)
+
+        date_range_regex = re.compile(r'^.*STATEMENT FROM ([A-Z]{3}) \d{2},? ?(\d{4})? TO ([A-Z]{3}) \d{2}, (\d{4})', re.MULTILINE)
+        date_range = {}
+
+        for row in rows:
+            if match := date_range_regex.search(row):
+                date_range[match.group(1)] = match.group(2) or match.group(4)
+                date_range[match.group(3)] = match.group(4)
+                break
+
+        # If the statement header wasn't found (format change), infer year mapping from filename
+        if not date_range:
+            # Expect pattern like ...YYYY-MM-DD.pdf
+            m = re.search(r'(\d{4})-(\d{2})-(\d{2})', os.path.basename(input_file))
+            if m:
+                end_year = int(m.group(1))
+                end_month = int(m.group(2))
+                months = ['JAN','FEB','MAR','APR','MAY','JUN','JUL','AUG','SEP','OCT','NOV','DEC']
+                for idx, mon in enumerate(months, start=1):
+                    year_for_mon = end_year if idx <= end_month else end_year - 1
+                    date_range[mon] = str(year_for_mon)
+
+        MONTHS = {
+            'JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN',
+            'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'
+        }
+        # Robust matcher for two date tokens at the beginning (optional spaces between month/day)
+        mon_alt = '(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)'
+        re_txn_prefix = re.compile(rf'^(?P<m1>{mon_alt})\s?(?P<d1>\d{{2}})(?P<m2>{mon_alt})\s?(?P<d2>\d{{2}})')
+        txn_rows = []
+
+        for row in rows:
+            # Some rows may contain multiple lines; check line by line
+            for line in row.splitlines():
+                s = line.strip()
+                if len(s) < 10:
+                    continue
+                m = re_txn_prefix.match(s)
+                if m and m.group('m1') in MONTHS and m.group('m2') in MONTHS:
+                    txn_rows.append(s)
+
+        for row in txn_rows:
+            m = re_txn_prefix.match(row)
+            if not m:
+                continue
+            date_1_month = m.group('m1')
+            date_1_day = m.group('d1')
+            date_2_month = m.group('m2')
+            date_2_day = m.group('d2')
+
+            transaction_date = None
+            try:
+                transaction_date = datetime.strptime(f'{date_1_month}-{date_1_day}-{date_range[date_1_month]}', '%b-%d-%Y')
+            except KeyError:
+                first_year = min([int(year) for year in date_range.values()]) if date_range else datetime.now().year
+                transaction_date = datetime.strptime(f'{date_1_month}-{date_1_day}-{first_year}', '%b-%d-%Y')
+            try:
+                posting_date = datetime.strptime(f'{date_2_month}-{date_2_day}-{date_range[date_2_month]}', '%b-%d-%Y')
+            except KeyError:
+                first_year = min([int(year) for year in date_range.values()]) if date_range else datetime.now().year
+                posting_date = datetime.strptime(f'{date_2_month}-{date_2_day}-{first_year}', '%b-%d-%Y')
+
+            # Description starts after the matched date tokens
+            desc_and_amt = row[m.end():]
+            # Extract the first monetary token (with optional $ and sign) to avoid trailing summary text
+            m_amt = re.search(r'(-?\$?\d{1,3}(?:,\d{3})*(?:\.\d{2}))', desc_and_amt)
+            if not m_amt:
+                # If parsing fails, skip this line
+                continue
+            description = desc_and_amt[:m_amt.start()]
+            amount = m_amt.group(1)
+
+            # Normalize description and negative sign conventions
+            if description.endswith('-'):
+                description = description[:-1]
+                if not amount.strip().startswith('-'):
+                    amount = '-' + amount
+
+            description = description.split("\n")[0].strip()
+            raw = row.strip()
+
+            amount = amount.replace('$', '').replace(',', '').replace("\n", "")
+            match_exchange_rate = re_exchange_rate.search(raw)
+            match_foreign_currency = re_foreign_currency.search(raw)
+            
+            if float(amount) > 0:
+                txns.append({
+                    'transaction_date': transaction_date,
+                    'posting_date': posting_date,
+                    'description': description,
+                    'credit': '',
+                    'debit': amount,
+                    'raw': raw,
+                    'exchange_rate': match_exchange_rate.group(1) if match_exchange_rate else None,
+                    'foreign_currency': match_foreign_currency.group(1) if match_foreign_currency else None,
+                    'amount_foreign': match_foreign_currency.group(2) if match_foreign_currency else None,
+                })
+            else:
+                txns.append({
+                    'transaction_date': transaction_date,
+                    'posting_date': posting_date,
+                    'description': description,
+                    'credit': amount,
+                    'debit': '',
+                    'raw': raw,
+                    'exchange_rate': match_exchange_rate.group(1) if match_exchange_rate else None,
+                    'foreign_currency': match_foreign_currency.group(1) if match_foreign_currency else None,
+                    'amount_foreign': match_foreign_currency.group(2) if match_foreign_currency else None,
+                })
+
+    txns = sorted(txns, key = lambda txn: txn['transaction_date'])
+
+    # Only write the CSV if at least one transaction was parsed successfully
+    if txns:
+        def _write_credit(writer: csv.writer):
+            writer.writerow([
+                'Transaction Date',
+                'Posting Date',
+                'Description',
+                'Credit',
+                'Debit',
+                'Amount Foreign Currency',
+                'Foreign Currency',
+                'Exchange Rate',
+                'Raw',
+            ])
+            for txn in txns:
+                writer.writerow([
+                    txn['transaction_date'].strftime('%Y-%m-%d'),
+                    txn['posting_date'].strftime('%Y-%m-%d'),
+                    txn['description'],
+                    txn['credit'],
+                    txn['debit'],
+                    txn['amount_foreign'],
+                    txn['foreign_currency'],
+                    txn['exchange_rate'],
+                    txn['raw'],
+                ])
+
+        _write_csv_with_retry(output_file, _write_credit)
+    else:
+        print(f"No credit transactions detected. Not creating '{output_file}'.")
+
+def process_chequing_statements(input_files: List[str], output_file: str):
+    csv_rows = []
+
+    for input_file in input_files:
+        root = _get_xml_root(input_file)
+        rows = []
+
+        continue_input_loop = False
+        for i_tag, tag in enumerate(root[0][1]):
+            if i_tag > 10:
+                continue_input_loop = True
+                break
+            if font := tag.get("font"):
+                if font.endswith("MetaBoldLF-Roman") or font.endswith("Utopia-Bold"):
+                    break
+        
+        if continue_input_loop:
+            print(f"Skipping {input_file}...")
+            continue
+
+        print(f'Processing {input_file}...')
+
+        blocks = []
+        pages = set()
+        for page_num, page in enumerate(root):
+            pages.add(page_num)
+            figure = page[1]
+            text = ''
+            last_x = None
+            last_x2 = None
+            block_x = None
+            width = 0
+            seen_text = False
+            for tag in figure:
+                clear_text = False
+                append_block = ""
+                if tag.tag == 'text':
+                    seen_text = True
+                    font = tag.attrib.get("font")
+                    if font:
+                        font = font.split("+")[1]
+                    size = float(tag.attrib['size'])
+                    x_pos = float(tag.attrib["bbox"].split(",")[0])
+                    y_pos = float(tag.attrib["bbox"].split(",")[1])
+                    x2_pos = float(tag.attrib["bbox"].split(",")[2])
+
+                    if last_x2 is not None:
+                        if x_pos - last_x2 > 5:
+                            append_block = text
+                            text = ""
+                            width = 0
+                        elif (x_pos - last_x2) > 0.7:
+                            text += " "
+                    last_x = x_pos
+                    last_x2 = x2_pos
+                    width += size
+                    if font in (font_txn, font_header):
+                        text += tag.text
+                    if block_x is None:
+                        block_x = x_pos
+                elif tag.tag != 'text' and text != '':
+                    if seen_text:
+                        append_block = text
+                    seen_text = False
+                    clear_text = True
+                    width = 0
+                    last_x2 = None
+                
+                if append_block:
+                    block = Block(page_num, block_x, x2_pos, y_pos, append_block.strip())
+                    blocks.append(block)
+                    block_x = None
+
+                if clear_text:
+                    text = ''
+
+        open_balance_parts = [b.text for b in blocks if b.text.startswith("Your opening balance")][0].split(" ")[-3:]
+        open_balance_date = parse(" ".join(open_balance_parts))
+        start_year = int(open_balance_parts[2])
+
+        header_sets = []
+        for page in pages:
+            page_blocks = [b for b in blocks if b.page == page]
+            end_of_header_index = 0
+
+            for i, block in enumerate(page_blocks):
+                if block.text == "Date":
+                    if other_blocks := page_blocks[i+1:i+5]:
+                        header_sets.append([block, *other_blocks])
+                        end_of_header_index = i + 4
+
+            page_blocks = [block for i, block in enumerate(page_blocks) if i > end_of_header_index]
+
+            if len(header_sets) <= page:
+                break
+
+            cell_pos = 0
+            i = 0
+            block_pos = 0
+            row = []
+            last_date = None
+
+            while block_pos < len(page_blocks):
+                row_pos = 0
+                block = page_blocks[block_pos]
+                block_consumed = False
+
+                headers = header_sets[block.page]
+
+                mid_point = (block.x2 - block.x) / 2 + block.x
+                for header in headers:
+                    if mid_point > header.x and mid_point < header.x2:
+                        row_pos = headers.index(header)
+
+                if i % 5 == row_pos:
+                    if i % 5 == 0:
+                        date = parse(f"{block.text} {start_year}")
+
+                        if date < open_balance_date:
+                            date = parse(f"{block.text} {start_year+1}")
+                        block.text = str(date.date())
+                        if block.text.strip():
+                            last_date = block.text
+                    block_consumed = True
+                    row.append(block.text)
+                elif i % 5 == 0 and page_blocks[block_pos].text == "Opening Balance":
+                    row.append(str(open_balance_date.date()))
+                elif last_date and i % 5 == 0:
+                    row.append(last_date)
+                else:
+                    row.append("")
+                if i % 5 == 4:
+                    csv_rows.append(row)
+                    row = []
+                if block_consumed:
+                    block_pos += 1
+                i += 1
+
+    def _write_chequing(writer: csv.writer):
+        writer.writerow([
+            "Date",
+            "Description",
+            "Withdrawls",
+            "Deposits",
+            "Balance"
         ])
 
-        for txn in txns:
-            csv_writer.writerow([
-                txn['transaction_date'].strftime('%Y-%m-%d'),
-                txn['posting_date'].strftime('%Y-%m-%d'),
-                txn['description'],
-                txn['amount'],
-                txn['amount_foreign'],
-                txn['foreign_currency'],
-                txn['exchange_rate'],
-                txn['raw'],
+        for row in csv_rows:
+            if "Opening Balance" in row:
+                description = "Opening Balance"
+                deposits = ""
+                withdrawals = ""
+            else:
+                description = row[1]
+                deposits = row[2]
+                withdrawals = row[3]
+
+            writer.writerow([
+                row[0],
+                description,
+                withdrawals,
+                deposits,
+                row[4]
             ])
 
-
-def main(args):
-    parser = argparse.ArgumentParser()
-
-    parser.add_argument(
-        "-o",
-        "--output",
-        dest="output_file",
-        default=default_output_file,
-        help=f"the output CSV file (default: {default_output_file})",
-    )
-    parser.add_argument(
-        "input_files",
-        nargs="*",
-        default=glob("*.pdf"),
-        help="input PDF statements (default: *.pdf)",
-    )
-
-    args = parser.parse_args()
-
-    if not args.input_files:
-        parser.error("no PDF files found in the current directory")
-
-    txns = []
-    for input_file in args.input_files:
-        txns += read_txns_from_pdf(input_file)
-    txns = sorted(txns, key=lambda txn: txn["transaction_date"])
-
-    write_txns_to_csv(txns, args.output_file)
-
+    _write_csv_with_retry(output_file, _write_chequing)
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    # If no arguments were provided, auto-discover PDFs in the current directory
+    if not input_files:
+        pdfs = []
+        # Match PDFs in current directory; on Windows glob is case-insensitive,
+        # so searching twice ("*.pdf" and "*.PDF") can create duplicates.
+        for pattern in ("*.pdf",):
+            pdfs.extend(glob.glob(os.path.join(os.getcwd(), pattern)))
+        # Deduplicate while preserving order
+        seen = set()
+        deduped = []
+        for p in pdfs:
+            key = os.path.normcase(os.path.abspath(p))
+            if key not in seen:
+                seen.add(key)
+                deduped.append(p)
+        pdfs = deduped
+        if not pdfs:
+            print("No input files provided and no .pdf files found in the current directory.")
+            print("Usage: python convert.py [optional files... (PDF or XML)]")
+            sys.exit(1)
+        input_files = pdfs
+
+    # Narrow down to visa/chequing/savings by filename when possible, otherwise try both processors gracefully
+    credit_files = [f for f in input_files if "visa" in os.path.basename(f).lower()]
+    chequing_files = [f for f in input_files if "chequing" in os.path.basename(f).lower()]
+    # Savings statements share the chequing layout but write to their own CSV
+    savings_files = [f for f in input_files if "savings" in os.path.basename(f).lower()]
+
+    # If nothing matched the patterns, be permissive and attempt to classify by structure
+    other_files = [f for f in input_files if f not in credit_files + chequing_files + savings_files]
+    for f in other_files:
+        # Heuristic: try both, catching errors and proceeding
+        try:
+            process_credit_statements([f], output_file_credit)
+        except Exception:
+            try:
+                process_chequing_statements([f], output_file_chequing)
+            except Exception:
+                print(f"Skipping unrecognized file type/format: {f}")
+
+    if credit_files:
+        process_credit_statements(credit_files, output_file_credit)
+
+    if chequing_files:
+        process_chequing_statements(chequing_files, output_file_chequing)
+
+    if savings_files:
+        process_chequing_statements(savings_files, output_file_savings)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pdfminer.six==20221105
+python-dateutil==2.9.0


### PR DESCRIPTION
## Summary

I added support for savings statements using the same chequing layout (uses chequing layout; outputs to `savings_transactions.csv`).

The Visa parser now handles both old and new RBC layouts (including FX fields and Raw column) from March 2025 onwards.

To address potential issues, such as writing to the CSV file while it's open in Excel, I implemented a retry prompt when CSV files are locked, asking users to close the file and press Enter before retrying.

Lastly, I updated the README to reflect changes in the schemas, auto-discovery, FX rates, and retry behavior; and added clarity around the installation/usage process.

## How to Test

1. Run `python convert.py`
2. Check outputs:
    - `credit_transactions.csv`: Transaction Date, Posting Date, Description, Credit, Debit, Amount Foreign Currency, Foreign Currency, Exchange Rate, Raw
    - `chequing_transactions.csv` / `savings_transactions.csv`: Date, Description, Withdrawls, Deposits, Balance
3. Open a CSV in Excel and re-run to see the retry prompt